### PR TITLE
Only set value variable when there is something to set

### DIFF
--- a/lib/ttl_memoizeable.rb
+++ b/lib/ttl_memoizeable.rb
@@ -57,11 +57,8 @@ module TTLMemoizeable
       define_method ttl_exceeded_method_name do
         return true unless instance_variable_defined?(value_variable_name)
 
-        instance_variable_get(ttl_variable_name) <= if time_based_ttl
-          ttl.ago
-        else
-          0
-        end
+        compared_to = time_based_ttl ? ttl.ago : 0
+        instance_variable_get(ttl_variable_name) <= compared_to
       end
 
       define_method extend_ttl_method_name do

--- a/lib/ttl_memoizeable.rb
+++ b/lib/ttl_memoizeable.rb
@@ -46,7 +46,6 @@ module TTLMemoizeable
       define_method setup_memoization_method_name do
         instance_variable_set(ttl_variable_name, expired_ttl) unless instance_variable_defined?(ttl_variable_name)
         instance_variable_set(mutex_variable_name, Mutex.new) unless instance_variable_defined?(mutex_variable_name)
-        instance_variable_set(value_variable_name, nil) unless instance_variable_defined?(value_variable_name)
       end
 
       define_method decrement_ttl_method_name do
@@ -56,6 +55,8 @@ module TTLMemoizeable
       end
 
       define_method ttl_exceeded_method_name do
+        return true unless instance_variable_defined?(value_variable_name)
+
         instance_variable_get(ttl_variable_name) <= if time_based_ttl
           ttl.ago
         else

--- a/spec/ttl_memoizeable_spec.rb
+++ b/spec/ttl_memoizeable_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe TTLMemoizeable do
 
   describe "#_setup_memoization_for_method" do
     let(:variables) do
-      [:@_ttl_for_bar, :@_mutex_for_bar, :@_value_for_bar]
+      [:@_ttl_for_bar, :@_mutex_for_bar]
     end
 
     it "sets instance variables" do
@@ -204,19 +204,27 @@ RSpec.describe TTLMemoizeable do
 
     before { Klass.bar }
 
-    context "time based ttl" do
-      let(:klass) { time_ttl_klass }
+    context "value variable has been set" do
+      context "time based ttl" do
+        let(:klass) { time_ttl_klass }
 
-      before { travel_to Time.current + fast_forward_time }
+        before { travel_to Time.current + fast_forward_time }
 
-      context "ttl hasn't been exceeded" do
-        let(:fast_forward_time) { 59.minutes }
+        context "ttl hasn't been exceeded" do
+          let(:fast_forward_time) { 59.minutes }
 
-        it { is_expected.to eq(false) }
+          it { is_expected.to eq(false) }
+        end
+
+        context "ttl has been exceeded" do
+          let(:fast_forward_time) { 60.minutes }
+
+          it { is_expected.to eq(true) }
+        end
       end
 
-      context "ttl has been exceeded" do
-        let(:fast_forward_time) { 60.minutes }
+      context "value variable has not been set" do
+        before { Klass.remove_instance_variable(:@_value_for_bar) }
 
         it { is_expected.to eq(true) }
       end


### PR DESCRIPTION
This prevents the possible race condition of setting a nil value variable due to multiple threads interacting with the `setup_memoization_method_name` method and setting the cached value.

Fixes #4